### PR TITLE
Improve English translation of "confinement"

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1,7 +1,7 @@
 {
   "covid19-alert": "Follow government restrictions. The responsibility is YOURS.",
   "title": "It remains open",
-  "subtitle": "Places that remain open during containment",
+  "subtitle": "Places that remain open during lockdown",
   "about": "About",
   "map": "Map",
   "search": "Search",
@@ -43,7 +43,7 @@
   "details": {
     "signal": "Report a change",
     "signal_done": "Your report has been registered. Thank you!",
-    "containment_opening_hours": "Opening hours outside the containment period",
+    "containment_opening_hours": "Opening hours outside the lockdown period",
     "containment_brand_hours": "Opening hours on the brand web page",
     "facebook": "Facebook page",
     "feature": {
@@ -119,11 +119,11 @@
       }
     },
     "state": {
-      "ouvert": "Place open during containment",
-      "ouvert_adapté": "Place open during containment with adapted hours",
-      "partiel": "Place potentially open during containment (to be checked)",
+      "ouvert": "Place open during lockdown",
+      "ouvert_adapté": "Place open during lockdown, with adapted hours",
+      "partiel": "Place potentially open during lockdown (to be checked)",
       "inconnu": "Place whose open status is not known",
-      "fermé": "Place closed during containment"
+      "fermé": "Place closed during lockdown"
     }
   }
 }


### PR DESCRIPTION
The term "containment" is a strategy applied to the virus, not to people.
The correct term when people are forbidden to go out is "lockdown".

See for instance:

https://en.wikipedia.org/wiki/2020_Italy_coronavirus_lockdown
https://fr.wikipedia.org/wiki/Confinement_de_2020_au_Royaume-Uni