### PR TITLE
Précision : ce lieu est-il ouvert **pendant le confinement**

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -20,7 +20,7 @@
     "sunday": "Sunday"
   },
   "contribute_form": {
-    "title": "Is this place open?",
+    "title": "Is this place open during lockdown?",
     "open": {
       "yes": "yes",
       "no": "no"

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -20,7 +20,7 @@
     "sunday": "Dimanche"
   },
   "contribute_form": {
-    "title": "Ce lieu est-il ouvert ?",
+    "title": "Ce lieu est-il ouvert pendant le confinement ?",
     "open": {
       "yes": "oui",
       "no": "non"


### PR DESCRIPTION
J'ai vu passer quelques notes qui indiquaient le lieu comme fermé, alors
qu'elle donnaient des horaires d'ouvertures adaptées dans le commentaire.
C'est simplement qu'on était dimanche, et visiblement certaines personnes
comprennent la question comme :

  « ce lieu est-il ouvert **maintenant** ? »

alors que la bonne question est :

  « ce lieu est-il ouvert **pendant le confinement** ? »