### PR TITLE
Page blanche sur firefox mobile

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -127,8 +127,15 @@ const vuetify = new Vuetify({
   }
 });
 
+const getLocale = () => {
+  try {
+    return localStorage.getItem('lang') || navigator.language.split('-')[0]
+  } catch (_) {
+    return 'en'
+  }
+}
 const i18n = new VueI18n({
-  locale: localStorage.getItem('lang') || navigator.language.split('-')[0],
+  locale: getLocale(),
   fallbackLocale: 'en',
   messages
 });


### PR DESCRIPTION
Firefox mobile 68
Android 8
One Plus 5T

J'avais une page blanche en chargeant le site.
Au debug j'ai trouvé que la ligne changée bloquait le chargement.
Du coup ça me fait l'appli en anglais.

Maintenant, je n'ai plus de page blanche mais les catégories et la carte ne s'affiche toujours pas.
![Screenshot_20200410-175830_Firefox](https://user-images.githubusercontent.com/787448/79004952-181a4480-7b56-11ea-8072-4ee2d098eb7a.png)

Va falloir que je lance un git bisect pour trouver l'autre truc qui foire parce que ma technique n'a pas marché pour trouver le deuxième bug.