### PR TITLE
DB statistics for brands, contributions, POIs

### DIFF
--- a/db/post_import.sh
+++ b/db/post_import.sh
@@ -2,3 +2,4 @@
 
 # Indexes
 psql -h "${PG_HOST}" -U "${PG_USER}" -p "${PG_PORT}" -d "${PG_DB}" -f indexes_post_import.sql
+psql -h "${PG_HOST}" -U "${PG_USER}" -p "${PG_PORT}" -d "${PG_DB}" -f post_import_stats.sql

--- a/db/post_import_stats.sql
+++ b/db/post_import_stats.sql
@@ -1,0 +1,35 @@
+--
+-- Init statistics tables
+--
+
+-- Features per brand
+CREATE TABLE IF NOT EXISTS stats_brand_count(
+	day DATE,
+	country VARCHAR,
+	name VARCHAR,
+	wikidata VARCHAR,
+	status VARCHAR,
+	amount INTEGER
+);
+
+-- Contributions
+CREATE OR REPLACE VIEW stats_contributions AS
+SELECT
+	ts::date AS day,
+	SUM((details is null)::int) AS direct_edits,
+	SUM((details is not null)::int) AS notes,
+	SUM((opening_hours is not null)::int) AS opening_hours_added
+	FROM contributions
+WHERE ts::date != current_date
+GROUP BY ts::date
+ORDER BY ts::date;
+
+-- Status per country
+CREATE TABLE IF NOT EXISTS stats_poi_count(
+	day DATE,
+	country VARCHAR,
+	total INT,
+	nb_open INT,
+	nb_closed INT,
+	nb_unknown INT
+);

--- a/db/stats_daily.sh
+++ b/db/stats_daily.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+CONNEXION=${1}
+OUTPUT=${2}
+
+# Append statistics to tables
+psql ${CONNEXION} -f stats_daily.sql
+
+# Export results into CSV files
+psql ${CONNEXION} -c "\copy stats_brand_count TO '${OUTPUT}/stats_brand_count.csv' CSV HEADER"
+psql ${CONNEXION} -c "\copy stats_poi_count TO '${OUTPUT}/stats_poi_count.csv' CSV HEADER"
+psql ${CONNEXION} -c "\copy (SELECT * FROM stats_contributions) TO '${OUTPUT}/stats_contributions.csv' CSV HEADER"

--- a/db/stats_daily.sql
+++ b/db/stats_daily.sql
@@ -1,0 +1,31 @@
+--
+-- Statistics requests to run daily
+--
+
+-- Features per brand
+INSERT INTO stats_brand_count(day, country, name, wikidata, status, amount)
+SELECT
+	current_date,
+	country,
+	brand,
+	brand_wikidata,
+	status,
+	COUNT(*)
+FROM poi_osm
+WHERE brand IS NOT NULL
+GROUP BY current_date, country, brand, brand_wikidata, status
+HAVING COUNT(*) >= 20
+ORDER BY country, COUNT(*) DESC;
+
+-- Status of POIs
+INSERT INTO stats_poi_count(day, country, total, nb_open, nb_closed, nb_unknown)
+SELECT
+	current_date,
+	country,
+	COUNT(*),
+	SUM((status IN ('open', 'open_adapted'))::int),
+	SUM((status = 'closed')::int),
+	SUM((status IN ('unknown', 'partial'))::int)
+FROM poi_osm
+GROUP BY current_date, country
+ORDER BY current_date, country;


### PR DESCRIPTION
Scripts qui génèrent des stats en base pour les POIs, contributions et marquest. Pour la mise en prod :

- [ ] Désactiver le cron qui génère le fichier [stats_brands.csv](https://download.osmontrouge.fr/caresteouvert/stats_brands.csv)
- [ ] Ajouter un cron journalier (plutôt fin de journée genre 23h30) sur le script `db/stats_daily.sh`. Ce script doit être appelé avec deux paramètres : chaîne de connexion PostgreSQL, et le dossier de destination des fichiers CSV (sans dernier `/`)
- [ ] Rendre ces fichiers dispos sur l'adresse `https://download.osmontrouge.fr/caresteouvert/`