### PR TITLE
Simpler fields in details for contrib form, introduce access:covid19

### DIFF
--- a/components/contribute_form.vue
+++ b/components/contribute_form.vue
@@ -112,6 +112,20 @@
           ></v-select>
         </label>
 
+        <label
+          v-if="showAccess"
+          class="d-block mt-2"
+        >
+          {{ $t('contribute_form.step3.access.title') }}
+          <v-select
+            v-model="access"
+            :items="accessItems"
+            filled
+            dense
+            hide-details
+          ></v-select>
+        </label>
+
         <label class="d-block pt-4">
           {{ $t('contribute_form.step3.details') }}
           <v-textarea
@@ -153,18 +167,22 @@ export default {
     return {
       step: 1,
       details: '',
+      access: null,
+      accessItems: [
+        { text: this.$t('contribute_form.step3.access.unknown'), value: null },
+        { text: this.$t('contribute_form.step3.access.yes'), value: 'yes' },
+        { text: this.$t('contribute_form.step3.access.no'), value: 'no' }
+      ],
       delivery: null,
       deliveryItems: [
         { text: this.$t('contribute_form.step3.delivery.unknown'), value: null },
         { text: this.$t('contribute_form.step3.delivery.yes'), value: 'yes' },
-        { text: this.$t('contribute_form.step3.delivery.only'), value: 'only' },
         { text: this.$t('contribute_form.step3.delivery.no'), value: 'no' }
       ],
       takeaway: null,
       takeawayItems: [
         { text: this.$t('contribute_form.step3.takeaway.unknown'), value: null },
         { text: this.$t('contribute_form.step3.takeaway.yes'), value: 'yes' },
-        { text: this.$t('contribute_form.step3.takeaway.only'), value: 'only' },
         { text: this.$t('contribute_form.step3.takeaway.no'), value: 'no' }
       ],
       loading: false,
@@ -178,6 +196,7 @@ export default {
     if (this.properties.opening_hours) {
       this.openingHours = this.parseOpeningHours(this.properties.opening_hours);
     }
+    this.access = this.parseTag('access:covid19', this.accessItems);
     this.delivery = this.parseTag('delivery:covid19', this.deliveryItems);
     this.takeaway = this.parseTag('takeaway:covid19', this.takeawayItems);
   },
@@ -193,6 +212,10 @@ export default {
 
     showOpeningHoursWithoutLockDown() {
       return !this.hasOpeningHours && this.openingHours.length !== 0;
+    },
+
+    showAccess() {
+      return this.showField('access:covid19', this.accessItems);
     },
 
     showDelivery() {
@@ -222,7 +245,8 @@ export default {
         tags: {
           opening_hours: this.openingHoursWithoutLockDown ? 'same': undefined,
           'delivery:covid19': this.delivery ? this.delivery : undefined,
-          'takeaway:covid19': this.takeaway ? this.takeaway : undefined
+          'takeaway:covid19': this.takeaway ? this.takeaway : undefined,
+          'access:covid19': this.access ? this.access : undefined
         }
       };
     }
@@ -285,7 +309,11 @@ export default {
     },
 
     parseTag(tag, items) {
-      const value = this.properties.tags[tag];
+      let value = this.properties.tags[tag];
+      if(['delivery:covid19', 'takeaway:covid19'].includes(tag) && value === "only") {
+        value = "yes";
+      }
+
       return items.map(e => e.value).includes(value) ? value : null;
     }
   }

--- a/locales/en.json
+++ b/locales/en.json
@@ -64,14 +64,18 @@
         "title": "This place offers delivery",
         "unknown": "I don't know",
         "yes": "Yes",
-        "only": "Only offers delivery",
         "no": "No"
       },
       "takeaway": {
         "title": "This place allows to purchase to take-away",
         "unknown": "I don't know",
         "yes": "Yes",
-        "only": "Take-away only",
+        "no": "No"
+      },
+      "access": {
+        "title": "Public can enter or stay inside this place",
+        "unknown": "I don't know",
+        "yes": "Yes",
         "no": "No"
       },
       "details": "Add details required during the lockdown"

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -64,14 +64,18 @@
         "title": "Ce lieu propose la livraison pendant le confinement",
         "unknown": "Ne sais pas",
         "yes": "Oui",
-        "only": "seulement la livraison",
         "no": "Non"
       },
       "takeaway": {
         "title": "Ce lieu propose la vente à emporter",
         "unknown": "Ne sais pas",
         "yes": "Oui",
-        "only": "Vente à emporter uniquement",
+        "no": "Non"
+      },
+      "access": {
+        "title": "Les clients peuvent entrer ou rester à l'intérieur",
+        "unknown": "Ne sais pas",
+        "yes": "Oui",
         "no": "Non"
       },
       "details": "Optionnel : ajouter d'autres détails liés au confinement"


### PR DESCRIPTION
Solves #325 

Changed contribution form :
- In details, no distinction between yes or only values for delivery/takeaway (wasn't clear)
- New field for saying if people can go inside place (tag `access:covid19`)