### PR TITLE
Improve readability of 'en' strings related to permanently closed businesses.

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -92,8 +92,8 @@
       "drive_through": "This place has a drive-through service",
       "details": "Optional : add details required during the lockdown",
       "details_error": "Should be either empty or at least 10 characters long",
-      "definite_closing": "Definite closing",
-      "details_definite_closing": "This place has definitely closed. What's there now instead ? Give as many details as possible, for example: under construction building, new business..."
+      "definite_closing": "Closed permanently",
+      "details_definite_closing": "This place has closed permanently. What's there now instead? Give as many details as possible, for example: under construction building, vacant, new business..."
     },
     "submit": "Publish",
     "cancel": "Cancel"


### PR DESCRIPTION
Improve readability of 'en' strings related to permanently closed businesses.

Fix #818 